### PR TITLE
Added .hidden-sublime-package for Debugger33

### DIFF
--- a/modules/adapters/util/__init__.py
+++ b/modules/adapters/util/__init__.py
@@ -7,6 +7,6 @@ from .import git
 from .import openvsx
 from .import vscode
 from .import bridge
-from .import process
+# from .import process
 from .import request
 from .import lsp

--- a/start.py
+++ b/start.py
@@ -55,6 +55,8 @@ def plugin_loaded() -> None:
 		with open(os.path.join(debugger33_path, "bridge33.py"), "w") as f:
 			data = sublime.load_resource("Packages/Debugger/modules/adapters/util/bridge33.py")
 			f.write(data)
+		with open(os.path.join(debugger33_path, ".hidden-sublime-package"), "w"):
+			pass
 
 	core.info('[startup]')
 	SettingsRegistery.initialize(on_updated=updated_settings)


### PR DESCRIPTION
`Package Control: List Packages` shows a package called Debugger33. Turns out this is a folder created by the Debugger package.

<img src=https://github.com/daveleroy/SublimeDebugger/assets/73487397/a870af9e-02b2-4456-b7a5-e60704a57764 width=400>

It is possible to hide these kinds of folders by adding an empty file named `.hidden-sublime-package`

<img src=https://github.com/daveleroy/SublimeDebugger/assets/73487397/e54e7300-c4db-4734-93aa-21ec4464fc8a width=400>

PS: I am new to open source (any feedback is appreciated), and I did not realize that the codebase was different from the stable version. While testing out my changes, there was an error in the modules/adapters/util/__init__.py file on the line `from .import process`. I could not find any file named process so I decided to comment it out so that I can proceed to test my changes. Kindly review, Thanks!