### PR TITLE
Add reverse_continue and step_back commands

### DIFF
--- a/Debugger.sublime-settings
+++ b/Debugger.sublime-settings
@@ -27,14 +27,14 @@
 
 	// Output panels outside of the debugger can be integrated into the tabbed debugger interface (note: In some cases output panels may cause issues and not work correctly depending on who owns them)
 	// An example for interating the Diagnostics panel of LSP and a Terminus output panel.
-	//
+	// 
 	// "integrated_output_panels": {
 	// 	"diagnostics": {
 	// 		"name": "Diagnostics",
 	// 	},
 	// 	"Terminus": {
 	// 		"name": "Terminal",
-	// 		"position": "bottom"
+	// 		"position": "bottom",
 	// 	}
 	// }
 	"integrated_output_panels": {},

--- a/contributes/Commands/Default.sublime-commands
+++ b/contributes/Commands/Default.sublime-commands
@@ -98,6 +98,13 @@
         }
     },
     {
+        "caption": "Debugger: Reverse Continue",
+        "command": "debugger",
+        "args": {
+            "action": "reverse_continue"
+        }
+    },
+    {
         "caption": "Debugger: Pause",
         "command": "debugger",
         "args": {
@@ -123,6 +130,13 @@
         "command": "debugger",
         "args": {
             "action": "step_out"
+        }
+    },
+    {
+        "caption": "Debugger: Step Back",
+        "command": "debugger",
+        "args": {
+            "action": "step_back"
         }
     },
     {
@@ -200,6 +214,27 @@
         "command": "debugger",
         "args": {
             "action": "lldb_toggle_dereference"
+        }
+    },
+    {
+        "caption": "Debugger: GDB Start recording for reverse debugging",
+        "command": "debugger",
+        "args": {
+            "action": "gdb_record"
+        }
+    },
+    {
+        "caption": "Debugger: GDB Step Back Over",
+        "command": "debugger",
+        "args": {
+            "action": "gdb_reverse_next"
+        }
+    },
+    {
+        "caption": "Debugger: GDB Step Back Out",
+        "command": "debugger",
+        "args": {
+            "action": "gdb_reverse_finish"
         }
     },
     {

--- a/contributes/Commands/Main.sublime-menu
+++ b/contributes/Commands/Main.sublime-menu
@@ -94,6 +94,13 @@
                         }
                     },
                     {
+                        "caption": "Reverse Continue",
+                        "command": "debugger",
+                        "args": {
+                            "action": "reverse_continue"
+                        }
+                    },
+                    {
                         "caption": "Pause",
                         "command": "debugger",
                         "args": {
@@ -119,6 +126,13 @@
                         "command": "debugger",
                         "args": {
                             "action": "step_out"
+                        }
+                    },
+                    {
+                        "caption": "Step Back",
+                        "command": "debugger",
+                        "args": {
+                            "action": "step_back"
                         }
                     },
                     {
@@ -202,6 +216,27 @@
                         "command": "debugger",
                         "args": {
                             "action": "lldb_toggle_dereference"
+                        }
+                    },
+                    {
+                        "caption": "GDB Start recording for reverse debugging",
+                        "command": "debugger",
+                        "args": {
+                            "action": "gdb_record"
+                        }
+                    },
+                    {
+                        "caption": "GDB Step Back Over",
+                        "command": "debugger",
+                        "args": {
+                            "action": "gdb_reverse_next"
+                        }
+                    },
+                    {
+                        "caption": "GDB Step Back Out",
+                        "command": "debugger",
+                        "args": {
+                            "action": "gdb_reverse_finish"
                         }
                     }
                 ]

--- a/modules/adapters/gdb.py
+++ b/modules/adapters/gdb.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from .import util
 from .. import dap
 from .. import core
+from .. import commands
+from ..debugger import Debugger
+
 
 class GDB(dap.AdapterConfiguration):
 
@@ -14,6 +17,26 @@ class GDB(dap.AdapterConfiguration):
 		repo='WebFreak001/code-debug'
 	)
 
+	def __init__(self) -> None:
+		commands.Command (
+			name='GDB Start recording for reverse debugging',
+			key='gdb_record',
+			action=lambda debugger: debugger.active.adapter_configuration.record(debugger),
+			enabled=Debugger.is_paused
+		)
+		commands.Command (
+			name='GDB Step Back Over',
+			key='gdb_reverse_next',
+			action=lambda debugger: debugger.active.adapter_configuration.reverse_next(debugger),
+			enabled=Debugger.is_paused
+		)
+		commands.Command (
+			name='GDB Step Back Out',
+			key='gdb_reverse_finish',
+			action=lambda debugger: debugger.active.adapter_configuration.reverse_finish(debugger),
+			enabled=Debugger.is_paused
+		)
+
 	async def start(self, log: core.Logger, configuration: dap.ConfigurationExpanded):
 		node = await util.get_and_warn_require_node(self.type, log)
 		install_path = self.installer.install_path()
@@ -22,3 +45,18 @@ class GDB(dap.AdapterConfiguration):
 			f'{install_path}/extension/out/src/gdb.js'
 		]
 		return dap.StdioTransport(command)
+
+	@core.run
+	async def record(self, debugger: Debugger) -> None:
+		try: await debugger.active.request('evaluate', {'expression': 'record'})
+		except core.Error as e: self.console.error(f'Unable to start recording: {e}')
+
+	@core.run
+	async def reverse_next(self, debugger: Debugger) -> None:
+		try: await debugger.active.request('evaluate', {'expression': 'reverse-next'})
+		except core.Error as e: self.console.error(f'Unable to reverse-next: {e}')
+
+	@core.run
+	async def reverse_finish(self, debugger: Debugger) -> None:
+		try: await debugger.active.request('evaluate', {'expression': 'reverse-finish'})
+		except core.Error as e: self.console.error(f'Unable to reverse-finish: {e}')

--- a/modules/commands.py
+++ b/modules/commands.py
@@ -108,6 +108,12 @@ class Commands:
 		action=lambda debugger: debugger.resume(),
 		enabled=Debugger.is_paused
 	)
+	reverse_continue = Command (
+		name='Reverse Continue',
+		key='reverse_continue',
+		action=lambda debugger: debugger.reverse_continue(),
+		enabled=Debugger.is_paused
+	)
 	pause = Command (
 		name='Pause',
 		key='pause',
@@ -130,6 +136,12 @@ class Commands:
 		name='Step Out',
 		key='step_out',
 		action=lambda debugger: debugger.step_out(),
+		enabled=Debugger.is_paused
+	)
+	step_back = Command (
+		name='Step Back',
+		key='step_back',
+		action=lambda debugger: debugger.step_back(),
 		enabled=Debugger.is_paused
 	)
 

--- a/modules/debugger.py
+++ b/modules/debugger.py
@@ -454,6 +454,11 @@ class Debugger (core.Dispose, dap.Debugger):
 		except core.Error as e: self.console.error(f'Unable to continue: {e}')
 
 	@core.run
+	async def reverse_continue(self) -> None:
+		try: await self.active.reverse_continue()
+		except core.Error as e: self.console.error(f'Unable to reverse continue: {e}')
+
+	@core.run
 	async def pause(self) -> None:
 		try: await self.active.pause()
 		except core.Error as e: self.console.error(f'Unable to pause: {e}')
@@ -472,6 +477,11 @@ class Debugger (core.Dispose, dap.Debugger):
 	async def step_out(self) -> None:
 		try: await self.active.step_out(granularity=self.stepping_granularity())
 		except core.Error as e: self.console.error(f'Unable to step out: {e}')
+
+	@core.run
+	async def step_back(self) -> None:
+		try: await self.active.step_back(granularity=self.stepping_granularity())
+		except core.Error as e: self.console.error(f'Unable to step backwards: {e}')
 
 	@core.run
 	async def stop(self, session: dap.Session|None = None) -> None:


### PR DESCRIPTION
Hi

I wanted to use the [reverse](https://sourceware.org/gdb/wiki/ReverseDebug) [debugging](https://gjbex.github.io/Defensive_programming_and_debugging/BugsAtRuntime/Debuggers/Gdb/gdb_reverse_debugging/) [features](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Process-Record-and-Replay.html) of `gdb`. 

It would be nice if the DAP supports reverse-next but as far as I see that's not supported.