### PR TITLE
Add `sourceLanguages` LLDB adapter setting

### DIFF
--- a/modules/adapters/lldb.py
+++ b/modules/adapters/lldb.py
@@ -81,6 +81,16 @@ class LLDB(dap.AdapterConfiguration):
 		if liblldb:
 			command.extend(['--liblldb', liblldb])
 
+		if 'sourceLanguages' in configuration:
+			import json
+
+			command.extend([
+				'--settings',
+				json.dumps({ 'sourceLanguages': configuration['sourceLanguages']}),
+			])
+
+			del configuration['sourceLanguages']
+
 		return dap.SocketTransport(command=command, port=port)
 
 	async def configuration_resolve(self, configuration: dap.ConfigurationExpanded):


### PR DESCRIPTION
[codelldb] adapter supports `sourceLanguages` configuration setting, that "enables language-specific features" in LLDB.

E.g.: when `"sourceLanguages": ["rust"]` enabled, debugger starts with `Rust: on panic` breakpoint preconfigured (instead of `C++: on throw`/`C++: on catch`).

<img width="998" alt="Screenshot 2024-06-10 at 15 40 27" src="https://github.com/daveleroy/SublimeDebugger/assets/2725918/8722237d-cd25-4726-b61f-57aa4dec41d8">

The handling for the option is, pretty much, copied from [codelldb]. See [here][codelldb-src-lang-cfg] and [here][codelldb-src-lang-cli].

[codelldb]: https://github.com/vadimcn/codelldb
[codelldb-src-lang-cfg]: https://github.com/vadimcn/codelldb/blob/master/extension/main.ts#L237-L240
[codelldb-src-lang-cli]: https://github.com/vadimcn/codelldb/blob/master/extension/novsc/adapter.ts#L37-L39